### PR TITLE
Fixed PhishTracks track URL for sharing

### DIFF
--- a/Phish Tracks/StreamingPlaylistItem.m
+++ b/Phish Tracks/StreamingPlaylistItem.m
@@ -51,7 +51,7 @@
 - (NSURL *)shareURL {
 	static NSURL *sub = nil;
 	if(sub == nil) {
-		sub = [NSURL URLWithString: [NSString stringWithFormat:@"http://www.phishtracks.com/show/%@/%@", self.show.showDate, self.song.slug, nil]];
+		sub = [NSURL URLWithString: [NSString stringWithFormat:@"http://www.phishtracks.com/shows/%@/%@", self.show.showDate, self.song.slug, nil]];
 	}
 	
 	return sub;


### PR DESCRIPTION
Links shared through the app are 404'ing on PhishTracks currently
